### PR TITLE
Add argument to specify output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,12 @@ gcc <regular arguments> -fplugin=externis -fplugin-arg-externis-trace=SOME_PATH/
 # Otherwise:
 gcc <regular arguments> -fplugin=/PATH/TO/build/externis.so -fplugin-arg-externis-trace=SOME_PATH/trace.json
 ```
-If a trace output path is not given, a temporary file with the name
+Alternatively, you can specify a directory to write the files to: 
+```bash 
+gcc <regular arguments> -fplugin=/PATH/TO/build/externis.so -fplugin-arg-externis-trace-dir=SOME_PATH/
+```
+In which case the output will be written to SOME_PATH/trace_XXXXXX.json
+If a trace output path or directory is not given, a temporary file with the name
 `/tmp/trace_XXXXXX.json` will be used instead.
 
 ## License & Copyright

--- a/externis.cc
+++ b/externis.cc
@@ -123,7 +123,7 @@ bool setup_output(int argc, plugin_argument *argv) {
   } else if (argc == 1 && !strcmp(argv[0].key, dir_flag_name)) {
     std::string file_template{argv[0].value};
     file_template += "/trace_XXXXXX.json";
-    int fd = mkstemps(file_template, 5);
+    int fd = mkstemps(file_template.data(), 5);
     if (fd == -1) {
       perror("Externis mkstemps error: ");
       return false;

--- a/externis.cc
+++ b/externis.cc
@@ -22,6 +22,7 @@
 #include <tree-check.h>
 #include <tree-pass.h>
 #include <tree.h>
+#include <string>
 
 #include "c-family/c-pragma.h"
 #include "cpplib.h"
@@ -106,8 +107,13 @@ bool setup_output(int argc, plugin_argument *argv) {
   // TODO: Validate we only compile one TU at a time.
   FILE *trace_file = nullptr;
   if (argc == 0) {
-    char file_template[] = "/tmp/trace_XXXXXX.json";
-    int fd = mkstemps(file_template, 5);
+    static constexpr auto default_directory = "/tmp";
+    const char* directory = getenv("EXTERNIS_OUTPUT_DIR"); 
+    if (!directory) {
+      directory = default_directory;
+    }
+    std::string file_template = std::string(default_directory) + "/trace_XXXXXX.json";
+    int fd = mkstemps(file_template.data(), 5);
     if (fd == -1) {
       perror("Externis mkstemps error: ");
       return false;


### PR DESCRIPTION
### Description

This MR allows externis to write files to any specified directory. This is useful as party of a build system, as you can then write all of the generated files to your build dir without adding custom flags for each source file. 