### PR TITLE
Fix building with ninja build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,11 @@ endif()
 set_target_properties(externis PROPERTIES CXX_STANDARD 20)
 set_target_properties(externis PROPERTIES COMPILE_FLAGS "-fno-rtti -g -Wall")
 set_target_properties(externis PROPERTIES PREFIX "" OUTPUT_NAME "externis")
+
 set(EXTERNIS_PLUGIN_PATH ${CMAKE_BINARY_DIR}/externis.so)
 install(TARGETS externis DESTINATION ${GCC_PLUGIN_INCLUDE})
 
 add_subdirectory(test)
+
+add_custom_target(wait_for_externis DEPENDS ${EXTERNIS_PLUGIN_PATH})
+add_dependencies(test wait_for_externis)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,11 +1,15 @@
 add_executable(test test.cc)
-set_target_properties(test PROPERTIES COMPILE_FLAGS "-fplugin=${EXTERNIS_PLUGIN_PATH} -fplugin-arg-externis-trace=${CMAKE_CURRENT_BINARY_DIR}/trace.json")
-add_dependencies(test externis)
+set_target_properties(
+    test
+    PROPERTIES
+        COMPILE_FLAGS
+        "-fplugin=${EXTERNIS_PLUGIN_PATH} -fplugin-arg-externis-trace=${CMAKE_CURRENT_BINARY_DIR}/trace.json"
+)
 
-# It's a bit weird, but it's convenient. This deletes the 
+# It's a bit weird, but it's convenient. This deletes the
 add_custom_target(
     remove_test ALL
-    COMMAND rm ${CMAKE_CURRENT_BINARY_DIR}/test 
+    COMMAND rm ${CMAKE_CURRENT_BINARY_DIR}/test
     COMMAND rm ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/test.dir/test.cc.o
     COMMAND echo "Removed!"
     DEPENDS test


### PR DESCRIPTION
Unsure of if it's a bug in cmake or ninja, but when using the cmake Ninja generator, the dependency ordering places the _link_ step of the test executable after the link step of externis.so. This means that ninja attempts to compile test.cc into test.o gets ordered before externis.so exists, which obviously doesn't work.

The cmake documentation specifies the DEPENDS in a custom target can only depend on files created in the directory where the custom target is declared, hence adding this new dependency rule in the root CMakeLists file.