### PR TITLE
Support targeting GCC other than the one being used to build externis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.12)
 project(externis)
 
+option(EXTERNIS_BUILD_TEST "Build the compiler plugin test" ON)
+
 if(NOT GCC_PLUGIN_INCLUDE)
     execute_process(
         COMMAND ${CMAKE_CXX_COMPILER} -print-file-name=plugin
@@ -31,7 +33,9 @@ set_target_properties(externis PROPERTIES PREFIX "" OUTPUT_NAME "externis")
 set(EXTERNIS_PLUGIN_PATH ${CMAKE_BINARY_DIR}/externis.so)
 install(TARGETS externis DESTINATION ${GCC_PLUGIN_INCLUDE})
 
-add_subdirectory(test)
+if(EXTERNIS_BUILD_TEST)
+    add_subdirectory(test)
 
-add_custom_target(wait_for_externis DEPENDS ${EXTERNIS_PLUGIN_PATH})
-add_dependencies(test wait_for_externis)
+    add_custom_target(wait_for_externis DEPENDS ${EXTERNIS_PLUGIN_PATH})
+    add_dependencies(test wait_for_externis)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,17 @@ install(TARGETS externis DESTINATION ${EXTERNIS_GCC_PLUGIN_DIR})
 if(EXTERNIS_BUILD_TEST)
     add_subdirectory(test)
 
-    add_custom_target(wait_for_externis DEPENDS ${EXTERNIS_PLUGIN_PATH})
-    add_dependencies(test wait_for_externis)
+    # When building with Ninja, the dependency tree for add_dependencies(test externis) sets up a
+    # rule the link step for test must run after the link step for externis; but that doesn't work
+    # because the compilation steps for test require externis
+    #
+    # However, using the custom target that depends on externis.so fails with GNU Make, because
+    # recursive GNU make doesn't have the knowledge to build files cross-directory; but using
+    # add_dependencies orders things correctly with GNU Make
+    if(CMAKE_GENERATOR STREQUAL "Ninja")
+        add_custom_target(wait_for_externis DEPENDS $<TARGET_FILE:externis>)
+        add_dependencies(test wait_for_externis)
+    else()
+        add_dependencies(test externis)
+    endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,22 +3,22 @@ project(externis)
 
 option(EXTERNIS_BUILD_TEST "Build the compiler plugin test" ON)
 
-if(NOT GCC_PLUGIN_INCLUDE)
+if(NOT EXTERNIS_GCC_PLUGIN_DIR)
     execute_process(
         COMMAND ${CMAKE_CXX_COMPILER} -print-file-name=plugin
-        OUTPUT_VARIABLE GCC_PLUGIN_INCLUDE
+        OUTPUT_VARIABLE EXTERNIS_GCC_PLUGIN_DIR
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
 endif()
 
-if(NOT EXISTS ${GCC_PLUGIN_INCLUDE}/include/gcc-plugin.h)
-    message(FATAL_ERROR "gcc-plugin.h not found under ${GCC_PLUGIN_INCLUDE}/include")
+if(NOT EXISTS ${EXTERNIS_GCC_PLUGIN_DIR}/include/gcc-plugin.h)
+    message(FATAL_ERROR "gcc-plugin.h not found under ${EXTERNIS_GCC_PLUGIN_DIR}/include")
 endif()
 
-message("GCC plugin headers found in " ${GCC_PLUGIN_INCLUDE})
+message("GCC plugin headers found in " ${EXTERNIS_GCC_PLUGIN_DIR})
 
 add_library(externis SHARED externis.cc tracking.cc output.cc)
-target_include_directories(externis PRIVATE ${GCC_PLUGIN_INCLUDE}/include)
+target_include_directories(externis PRIVATE ${EXTERNIS_GCC_PLUGIN_DIR}/include)
 
 # Optional, useful for debugging.
 find_package(fmt)
@@ -31,7 +31,7 @@ set_target_properties(externis PROPERTIES COMPILE_FLAGS "-fno-rtti -g -Wall")
 set_target_properties(externis PROPERTIES PREFIX "" OUTPUT_NAME "externis")
 
 set(EXTERNIS_PLUGIN_PATH ${CMAKE_BINARY_DIR}/externis.so)
-install(TARGETS externis DESTINATION ${GCC_PLUGIN_INCLUDE})
+install(TARGETS externis DESTINATION ${EXTERNIS_GCC_PLUGIN_DIR})
 
 if(EXTERNIS_BUILD_TEST)
     add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,17 @@
 cmake_minimum_required(VERSION 3.12)
 project(externis)
 
-execute_process(
-    COMMAND gcc -print-file-name=plugin
-    OUTPUT_VARIABLE GCC_PLUGIN_INCLUDE
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
+if(NOT GCC_PLUGIN_INCLUDE)
+    execute_process(
+        COMMAND ${CMAKE_CXX_COMPILER} -print-file-name=plugin
+        OUTPUT_VARIABLE GCC_PLUGIN_INCLUDE
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+endif()
+
+if(NOT EXISTS ${GCC_PLUGIN_INCLUDE}/include/gcc-plugin.h)
+    message(FATAL_ERROR "gcc-plugin.h not found under ${GCC_PLUGIN_INCLUDE}/include")
+endif()
 
 message("GCC plugin headers found in " ${GCC_PLUGIN_INCLUDE})
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,23 @@ sudo make install
 
 Prebuilt binaries may be provided in the future.
 
+### Cross-Compilation
+
+By default, the externis build will execute
+`${CMAKE_CXX_COMPILER} -print-file-name=plugin` to determine the location of
+the gcc plugin header and plugin install location. If you plan to use externis
+with the compiler that you use to build externis, this works just fine; however,
+if you want to build externis for use with a different `g++` (for example,
+`g++-arm-none-eabi`), this will not work.
+
+To build externis for use with some other `g++`, find the plugin dir for that
+gcc (You can run `g++-arm-none-eabi -print-file-name=plugin` yourself), and
+configure externis with `-DEXTERNIS_GCC_PLUGIN_DIR=[that path]`, or for
+shorthand, use
+`cmake -DEXTERNIS_GCC_PLUGIN_DIR=$([your g++] -print-file-name=plugin)`. When
+doing this, it will likely also be necessary to use `-DEXTERNIS_BUILD_TEST=OFF`
+to disable the build test validates externis.
+
 ## Usage
 
 After building the plugin, you can use it by passing the following additional
@@ -61,8 +78,8 @@ gcc <regular arguments> -fplugin=externis -fplugin-arg-externis-trace=SOME_PATH/
 # Otherwise:
 gcc <regular arguments> -fplugin=/PATH/TO/build/externis.so -fplugin-arg-externis-trace=SOME_PATH/trace.json
 ```
-Alternatively, you can specify a directory to write the files to: 
-```bash 
+Alternatively, you can specify a directory to write the files to:
+```bash
 gcc <regular arguments> -fplugin=/PATH/TO/build/externis.so -fplugin-arg-externis-trace-dir=SOME_PATH/
 ```
 In which case the output will be written to SOME_PATH/trace_XXXXXX.json


### PR DESCRIPTION
In a cross-compilation scenario, it's not possible to use GCC to build externis and then turn around and use the same GCC with externis - it's necessary to use some other GCC toolchain targeting your build host to build externis so that it can run with the cross-compilation GCC.

Adding the options to specify the GCC include directory manually and disable the tests supports this use case; I can now do

```
cmake -B build -DGCC_PLUGIN_INCLUDE=/opt/my-aarch64-toolchain/path/to/gcc/plugin
cmake --build build
cmake --install build

/opt/my-aarch64-toolchain/usr/bin/g++ -fplugin=externis ...
```
in order to use externis while building code that targets some other system.