### PR TITLE
Use main_input_filename as TU event name (where not null)

### DIFF
--- a/output.cc
+++ b/output.cc
@@ -90,7 +90,7 @@ void add_event(const TraceEvent &event) {
 }
 
 void write_all_events() {
-  add_event(TraceEvent{main_input_filename,
+  add_event(TraceEvent{main_input_filename ? main_input_filename : "TU",
                        EventCategory::TU,
                        {0, ns_from_start()},
                        std::nullopt});

--- a/output.cc
+++ b/output.cc
@@ -90,8 +90,10 @@ void add_event(const TraceEvent &event) {
 }
 
 void write_all_events() {
-  add_event(
-      TraceEvent{"TU", EventCategory::TU, {0, ns_from_start()}, std::nullopt});
+  add_event(TraceEvent{main_input_filename,
+                       EventCategory::TU,
+                       {0, ns_from_start()},
+                       std::nullopt});
   write_preprocessing_events();
   write_opt_pass_events();
   write_all_functions();


### PR DESCRIPTION
When analysing traces from lots of translation units together, it's a lot more convenient if the TU events carry some indication of _which_ TU they correspond to.

This is a breaking change if anyone happened to be relying on all the TU events being called "TU", but the category field is still "TU" so it will still be very easily possible to programatically detect TU events in the output if desired.