### PR TITLE
Allow installing to default destination rather than GCC plugin dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 project(externis)
 
 option(EXTERNIS_BUILD_TEST "Build the compiler plugin test" ON)
+option(EXTERNIS_INSTALL_TO_PLUGIN_DIR "Install Externis into the GCC plugin directory" ON)
 
 if(NOT EXTERNIS_GCC_PLUGIN_DIR)
     execute_process(
@@ -31,7 +32,12 @@ set_target_properties(externis PROPERTIES COMPILE_FLAGS "-fno-rtti -g -Wall")
 set_target_properties(externis PROPERTIES PREFIX "" OUTPUT_NAME "externis")
 
 set(EXTERNIS_PLUGIN_PATH ${CMAKE_BINARY_DIR}/externis.so)
-install(TARGETS externis DESTINATION ${EXTERNIS_GCC_PLUGIN_DIR})
+
+if (EXTERNIS_INSTALL_TO_PLUGIN_DIR)
+    install(TARGETS externis DESTINATION ${EXTERNIS_GCC_PLUGIN_DIR})
+else()
+    install(TARGETS externis)
+endif()
 
 if(EXTERNIS_BUILD_TEST)
     add_subdirectory(test)

--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ The requirements for building Externis are:
     similar to get the GCC plugin headers installed.
  3. **CMake** (but barely).
 
-After downloading the source code, you can build and install the plugin into
-GCC's plugin directory with
+After downloading the source code, you can build and install the plugin with
 
 ```bash
 mkdir build && cd build
@@ -48,6 +47,8 @@ cmake ..
 make externis
 sudo make install
 ```
+
+By default, Externis is installed into GCC's plugin directory, but you can control this behaviour with the CMake option `EXTERNIS_INSTALL_TO_PLUGIN_DIR`.
 
 Prebuilt binaries may be provided in the future.
 


### PR DESCRIPTION
We have a workflow which makes the behaviour of Externis automatically installing itself into the GCC plugin directory somewhat awkward, as we want to compile Externis away from where it will be used.
This adds a CMake option to disable that behaviour (and use the default installation prefix instead).